### PR TITLE
Fixed an issue where speakers couldn't be picked up when access was given to others.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -22,7 +22,19 @@ end
 
 ---@param speakerId number
 local updateSpeakersById = function(speakerId)
-    TriggerClientEvent('mt_speakers:client:updateSpeakerById', -1, speakerId, speakers[speakerId])
+    local speakerData = {
+        item = speakers[speakerId].item,
+        location = speakers[speakerId].location,
+        users = speakers[speakerId].users,
+        id = speakers[speakerId].id,
+        owner = speakers[speakerId].owner
+        --exclude 'prop' as it's client-side only
+    }
+    TriggerClientEvent('mt_speakers:client:updateSpeakerById', -1, speakerId, speakerData)
+end
+
+local updateSpeakerUsers = function(speakerId)
+    TriggerClientEvent('mt_speakers:client:updateSpeakerUsers', -1, speakerId, speakers[speakerId].users)
 end
 
 ---@param citizenid string
@@ -162,7 +174,7 @@ lib.callback.register('mt_speakers:server:addAccess', function(source, user, spe
     if not users then users = {} end
     users[#users+1] = user
     speakers[speakerId].users = users
-    updateSpeakersById(speakerId)
+    updateSpeakerUsers(speakerId) -- Use specific update instead of full sync
     MySQL.update.await('UPDATE speakers SET `users` = ? WHERE id = ?', { json.encode(users), speakerId })
     return true
 end)
@@ -175,7 +187,7 @@ lib.callback.register('mt_speakers:server:removeAccess', function(source, user, 
         if uv.citizenid == user.citizenid then users[uk] = nil end
     end
     speakers[speakerId].users = users
-    updateSpeakersById(speakerId)
+    updateSpeakerUsers(speakerId) -- Use specific update instead of full sync
     MySQL.update.await('UPDATE speakers SET `users` = ? WHERE id = ?', { json.encode(users), speakerId })
     return true
 end)


### PR DESCRIPTION
**Problem**

- Speaker deletion crashed with `DeleteObject.lua:9: bad argument #1 to '_ii' (number expected, got table)` when speakers were shared between players.

**Root Cause**

- Server was overwriting client-side entity handles with server data when updating shared speakers.

**Solution**

- Preserve client-side entity handles during server updates
- Add proper type validation before entity deletion
- Use targeted updates instead of full object sync

**Changes**

- Fixed `updateSpeakerById` to preserve prop entity handles
- Added error handling in `deleteSpeaker` event
- Created specific `updateSpeakerUsers` event for user changes


with <3 from sugawy